### PR TITLE
fix read build target

### DIFF
--- a/lib/bake/adapters/nerves.ex
+++ b/lib/bake/adapters/nerves.ex
@@ -7,7 +7,7 @@ defmodule Bake.Adapters.Nerves do
   require Logger
   defp nerves_home do
     if Process.whereis(Bake.State) do
-	    Bake.State.fetch!(:nerves_home)
+      Bake.State.fetch!(:nerves_home)
     else
       Path.expand(System.get_env("NERVES_HOME") || @nerves_home)
     end
@@ -56,7 +56,9 @@ defmodule Bake.Adapters.Nerves do
             {:ok, term} -> term
             {:error, _} -> decode_elixir(file)
           end
-          unless build_env[:"NERVES_TARGET"] == to_string(target) do
+
+          build_target = to_keyword_list(build_env)[:NERVES_TARGET]
+          unless build_target == to_string(target) do
             cmd = clean_target(cmd)
           end
         _ -> cmd = clean_target(cmd)
@@ -175,5 +177,9 @@ defmodule Bake.Adapters.Nerves do
     mix deps.get &&
     mix deps.compile &&
     """
+  end
+
+  defp to_keyword_list(build_env) do
+    Enum.map(build_env, fn {k, v} -> {String.to_atom(k), v})
   end
 end


### PR DESCRIPTION
Hi, 

I'm trying out Nerves and observe that Bake always clean and rebuild all the dependencies. The reason is that reading from `nerves_env` with `decode_term` produces a list of tuples with string keys, and cannot be extract with `build_env[:"NERVES_TARGET"]`.

``` elixir
iex> {:ok, build_env} = decode_term(file)
{:ok,
 [{"NERVES_APP", "/Users/tung/Projects/pi-portal/portal_agent"},
  {"NERVES_TOOLCHAIN",
   "/Users/tung/.nerves/toolchains/nerves-armv6-rpi-linux-gnueabi-darwin-x86_64-v0.6.0"},
  {"NERVES_SYSTEM", "/Users/tung/.nerves/systems/nerves/rpi-0.3.1"},
  {"NERVES_TARGET", "rpi"}, {"MIX_ENV", "dev"}]}
iex> build_env[:"NEVERS_TARGET"]
nil
```

I'm using Elixir 1.2.1

``` sh
$ elixir --version
Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.2.1
```

May be the better place to put this fix is in `decode_term`, but I'm not sure.

Thank you guys very much for the hardwork.
