### PR TITLE
Handling empty 'bake' and 'bake help' commands

### DIFF
--- a/lib/bake/cli/help.ex
+++ b/lib/bake/cli/help.ex
@@ -13,6 +13,9 @@ defmodule Bake.Cli.Help do
     """
   end
 
+  def main([]) do
+    Bake.Shell.info Bake.Cli.menu
+  end
   def main(args) do
     {_opts, cmd, _} = OptionParser.parse(args, switches: @switches)
     mod = List.first(cmd)

--- a/lib/bake/cli/menu.ex
+++ b/lib/bake/cli/menu.ex
@@ -10,6 +10,7 @@ defmodule Bake.Cli.Menu do
 
       def invalid_cmd,      do: Bake.Shell.info menu
       def invalid_cmd(""),  do: Bake.Shell.info menu
+      def invalid_cmd([]),  do: Bake.Shell.info menu
       def invalid_cmd(cmd) do
         mod = Atom.to_string(__MODULE__)
           |> String.split(".")


### PR DESCRIPTION
Redirect to default info menu rather than a `capitalize` error or `undefined module`.
